### PR TITLE
schema changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ And adding this to the top of your `app.js` **before** `require`/`import`ing of 
 
 ```javascript
 require("honeycomb-nodejs-magic")({
-  writeKey: "YOUR-WRITE-KEY"
-  /* ... additional optional configuration ... */,
+  writeKey: "YOUR-WRITE-KEY",
+  /* ... additional optional configuration ... */
 });
 ```
 
@@ -67,21 +67,21 @@ For available configuration options per instrumentation, see the Instrumented pa
 ```javascript
 {
   "Timestamp": "2018-03-20T00:47:25.339Z",
-  "express.baseUrl": "",
-  "express.fresh": false,
-  "express.hostname": "localhost",
-  "express.http_version": "1.1",
-  "express.ip": "127.0.0.1",
-  "express.method": "POST",
-  "express.originalUrl": "/checkValid",
-  "express.path": "/checkValid",
-  "express.protocol": "http",
-  "express.query": "{}",
-  "express.response_time_ms": 15.229326,
-  "express.secure": false,
-  "express.status_code": "200",
-  "express.url": "/checkValid",
-  "express.xhr": true,
+  "baseUrl": "",
+  "fresh": false,
+  "hostname": "localhost",
+  "httpVersion": "1.1",
+  "ip": "127.0.0.1",
+  "method": "POST",
+  "originalUrl": "/checkValid",
+  "path": "/checkValid",
+  "protocol": "http",
+  "query": "{}",
+  "durationMs": 15.229326,
+  "secure": false,
+  "statusCode": "200",
+  "url": "/checkValid",
+  "xhr": true,
   "meta.instrumentation_count": 4,
   "meta.instrumentations": "[\"child_process\",\"express\",\"http\",\"https\"]",
   "meta.request_id": "11ad83a2-ca8d-4918-9db2-27524456d9f7",

--- a/README.md
+++ b/README.md
@@ -57,10 +57,39 @@ For available configuration options per instrumentation, see the Instrumented pa
 
 # Example questions
 
-* Which of my app's requests are the slowest?
+* Which of my express app's endpoints are the slowest?
+
+```
+BREAKDOWN: url
+CALCULATE: P99(durationMs)
+FILTER: meta.type == express
+ORDER BY: P99(durationMs) DESC
+```
+
 * Where's my app doing the most work / spending the most time?
+
+```
+BREAKDOWN: meta.type
+CALCULATE: P99(durationMs)
+ORDER BY: P99(durationMs) DESC
+```
+
 * Which users are using the endpoint that I'd like to deprecate?
+
+```
+BREAKDOWN: user.email
+CALCULATE: COUNT
+FILTER: url == <endpoint-url>
+```
+
 * Which XHR endpoints take the longest?
+
+```
+BREAKDOWN: url
+CALCULATE: P99(durationMs)
+FILTER: meta.type == express AND xhr == true
+ORDER BY: P99(durationMs) DESC
+```
 
 # Example event
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -7,6 +7,7 @@ const debug = require("debug")("honeycomb-magic:event"),
   uppercamelcase = require("uppercamelcase"),
   tracker = require("./async_tracker"),
   magic = require("./magic"),
+  schema = require("./schema"),
   pkg = require(path.join(__dirname, "..", "package.json"));
 
 let eventAPI;
@@ -58,24 +59,24 @@ class MockEventAPI {
     tracker.setTracked(requestContext);
     return this.startEvent(requestContext, source);
   }
-  finishRequest(ev, durationMSField) {
-    this.finishEvent(ev, null, durationMSField);
+  finishRequest(ev) {
+    this.finishEvent(ev, null);
     tracker.deleteTracked();
   }
   startEvent(context, source) {
     const eventPayload = {
-      "meta.request_id": context.id,
-      "meta.type": source, // XXX(toshok) rename "type" to "source"?
+      [schema.REQUEST_ID]: context.id,
+      [schema.EVENT_TYPE]: source,
       startTime: Date.now(),
       startTimeHR: process.hrtime(),
     };
     this.eventStack.push(eventPayload);
     return eventPayload;
   }
-  finishEvent(ev, rollup, durationMsField) {
+  finishEvent(ev, rollup) {
     Object.assign(ev, {
       appEventPrefix: rollup,
-      [durationMsField]: 0,
+      [schema.DURATION_MS]: 0,
     });
     // pop it off the stack
     const idx = this.eventStack.indexOf(ev);
@@ -112,15 +113,15 @@ class LibhoneyEventAPI {
     return this.startEvent(requestContext, source);
   }
 
-  finishRequest(ev, durationMSField) {
-    this.finishEvent(ev, null, durationMSField);
+  finishRequest(ev) {
+    this.finishEvent(ev, null);
     tracker.deleteTracked();
   }
 
   startEvent(context, source) {
     const eventPayload = {
-      "meta.request_id": context.id,
-      "meta.type": source, // XXX(toshok) rename "type" to "source"?
+      [schema.REQUEST_ID]: context.id,
+      [schema.EVENT_TYPE]: source,
       startTime: Date.now(),
       startTimeHR: process.hrtime(),
     };
@@ -128,7 +129,7 @@ class LibhoneyEventAPI {
     return eventPayload;
   }
 
-  finishEvent(ev, rollup, durationMsField = "duration_ms") {
+  finishEvent(ev, rollup) {
     const context = tracker.getTracked();
     if (!context) {
       // valid, since we can end up in our instrumentation outside of requests we're tracking
@@ -158,7 +159,7 @@ class LibhoneyEventAPI {
     const { startTime, startTimeHR } = payload;
     const duration = process.hrtime(startTimeHR);
     const durationMs = (duration[0] * 1e9 + duration[1]) / 1e6;
-    payload[durationMsField] = durationMs;
+    payload[schema.DURATION_MS] = durationMs;
     delete payload.startTime;
     delete payload.startTimeHR;
 
@@ -172,15 +173,11 @@ class LibhoneyEventAPI {
           debug("no event to rollup into");
         } else {
           const rootPayload = context.stack[0];
-          const rootType = rootPayload["meta.type"];
-          const type = payload["meta.type"];
+          const type = payload[schema.EVENT_TYPE];
+          incr(rootPayload, `total${uppercamelcase(type)}${uppercamelcase(rollup)}_count`);
           incr(
             rootPayload,
-            `${rootType}.total${uppercamelcase(type)}${uppercamelcase(rollup)}_count`
-          );
-          incr(
-            rootPayload,
-            `${rootType}.total${uppercamelcase(type)}${uppercamelcase(rollup)}Duration_ms`,
+            `total${uppercamelcase(type)}${uppercamelcase(rollup)}Duration_ms`,
             durationMs
           );
         }
@@ -192,8 +189,8 @@ class LibhoneyEventAPI {
       ev.timestamp = new Date(startTime);
       ev.add(payload);
       ev.add({
-        "meta.instrumentations": active_instrumentations,
-        "meta.instrumentation_count": active_instrumentation_count,
+        [schema.INSTRUMENTATIONS]: active_instrumentations,
+        [schema.INSTRUMENTATION_COUNT]: active_instrumentation_count,
       });
       ev.send();
     });
@@ -227,7 +224,7 @@ class LibhoneyEventAPI {
 
 const customContext = {
   add(key, val) {
-    eventAPI.addContext({ [`custom.${key}`]: val });
+    eventAPI.addContext({ [schema.customColumn(key)]: val });
   },
 };
 
@@ -237,8 +234,8 @@ exports.resetForTesting = resetForTesting;
 exports.startRequest = function startRequest(source, requestId) {
   return eventAPI.startRequest(source, requestId);
 };
-exports.finishRequest = function finishRequest(ev, durationMSField) {
-  return eventAPI.finishRequest(ev, durationMSField);
+exports.finishRequest = function finishRequest(ev) {
+  return eventAPI.finishRequest(ev);
 };
 exports.addContext = function addContext(map) {
   return eventAPI.addContext(map);
@@ -246,8 +243,8 @@ exports.addContext = function addContext(map) {
 exports.startEvent = function startEvent(context, source) {
   return eventAPI.startEvent(context, source);
 };
-exports.finishEvent = function finishEvent(ev, rollup, durationMsField) {
-  return eventAPI.finishEvent(ev, rollup, durationMsField);
+exports.finishEvent = function finishEvent(ev, rollup) {
+  return eventAPI.finishEvent(ev, rollup);
 };
 const dumpRequestContext = (exports.dumpRequestContext = function dumpRequestContext() {
   return eventAPI.dumpRequestContext();

--- a/lib/event.test.js
+++ b/lib/event.test.js
@@ -1,6 +1,7 @@
 /* global require beforeEach afterEach test expect __dirname */
 const path = require("path"),
   event = require("./event"),
+  schema = require("./schema"),
   tracker = require("./async_tracker"),
   pkg = require(path.join(__dirname, "..", "package.json"));
 
@@ -31,8 +32,8 @@ test("startRequest starts tracking and creates an initial event, finishRequest s
   // the stack consists solely of the request's event
   expect(context.stack).toEqual([eventPayload]);
   // and it should have these properties
-  expect(eventPayload["meta.type"]).toBe("source");
-  let requestId = eventPayload["meta.request_id"];
+  expect(eventPayload[schema.EVENT_TYPE]).toBe("source");
+  let requestId = eventPayload[schema.REQUEST_ID];
   expect(requestId).not.toBeUndefined();
   let startTime = eventPayload.startTime;
   expect(startTime).not.toBeUndefined();
@@ -49,9 +50,9 @@ test("startRequest starts tracking and creates an initial event, finishRequest s
   let sent = honey.transmission.events[0];
   let postData = JSON.parse(sent.postData);
   expect(sent.timestamp).toEqual(new Date(startTime));
-  expect(postData["meta.type"]).toBe("source");
-  expect(postData["meta.request_id"]).toBe(requestId);
-  expect(postData["duration_ms"]).not.toBeUndefined();
+  expect(postData[schema.EVENT_TYPE]).toBe("source");
+  expect(postData[schema.REQUEST_ID]).toBe(requestId);
+  expect(postData[schema.DURATION_MS]).not.toBeUndefined();
 });
 
 test("ending events out of order isn't allowed", () => {
@@ -80,23 +81,15 @@ test("sub-events can opt to rollup count/duration into request events", () => {
   let eventPayload = event.startEvent(context, "source2");
   event.finishEvent(eventPayload, "rollup");
 
-  let durationMS = eventPayload.duration_ms;
-  expect(requestPayload["source.totalSource2Rollup_count"]).toBe(1);
-  expect(requestPayload["source.totalSource2RollupDuration_ms"]).toBe(durationMS);
+  let durationMS = eventPayload[schema.DURATION_MS];
+  expect(requestPayload["totalSource2Rollup_count"]).toBe(1);
+  expect(requestPayload["totalSource2RollupDuration_ms"]).toBe(durationMS);
 
   // another event from the same source
   let event2Payload = event.startEvent(context, "source2");
   event.finishEvent(event2Payload, "rollup");
 
-  let duration2MS = event2Payload.duration_ms;
-  expect(requestPayload["source.totalSource2Rollup_count"]).toBe(2);
-  expect(requestPayload["source.totalSource2RollupDuration_ms"]).toBe(durationMS + duration2MS);
-});
-
-test("events can specify the column name used to store event duration_ms", () => {
-  let requestPayload = event.startRequest("source");
-
-  event.finishRequest(requestPayload, "myOwnSpecialDurationMsField");
-
-  expect(requestPayload.myOwnSpecialDurationMsField).not.toBeUndefined();
+  let duration2MS = event2Payload[schema.DURATION_MS];
+  expect(requestPayload["totalSource2Rollup_count"]).toBe(2);
+  expect(requestPayload["totalSource2RollupDuration_ms"]).toBe(durationMS + duration2MS);
 });

--- a/lib/magic/express-magic.js
+++ b/lib/magic/express-magic.js
@@ -2,6 +2,7 @@
 const debug = require("debug")("honeycomb-magic:magic:express"),
   onHeaders = require("on-headers"),
   tracker = require("../async_tracker"),
+  schema = require("../schema"),
   event = require("../event");
 
 // returns the header name/value for the first header with a value in the request.
@@ -74,7 +75,7 @@ const getUserContext = (userContext, req) => {
   for (const k of keys) {
     const v = userObject[k];
     if (typeof v !== "function") {
-      userEventContext[`express.user.${k}`] = v;
+      userEventContext[`user.${k}`] = v;
     }
   }
   return userEventContext;
@@ -85,24 +86,24 @@ const getMagicMiddleware = ({ userContext, requestIdSource }) => (req, res, next
   let ev = event.startRequest("express", requestIdContext.requestId);
 
   event.addContext({
-    "meta.request_id_source": requestIdContext.source,
+    [schema.REQUEST_ID_SOURCE]: requestIdContext.source,
   });
 
   event.addContext({
-    ["express.hostname"]: req.hostname,
-    ["express.baseUrl"]: req.baseUrl,
-    ["express.url"]: req.url,
-    ["express.originalUrl"]: req.originalUrl,
-    ["express.ip"]: req.ip,
-    ["express.secure"]: req.secure,
-    ["express.method"]: req.method,
-    ["express.route"]: req.route ? req.route.path : undefined,
-    ["express.protocol"]: req.protocol,
-    ["express.path"]: req.path,
-    ["express.query"]: req.query,
-    ["express.http_version"]: req.httpVersion,
-    ["express.fresh"]: req.fresh,
-    ["express.xhr"]: req.xhr,
+    hostname: req.hostname,
+    baseUrl: req.baseUrl,
+    url: req.url,
+    originalUrl: req.originalUrl,
+    ip: req.ip,
+    secure: req.secure,
+    method: req.method,
+    route: req.route ? req.route.path : undefined,
+    protocol: req.protocol,
+    path: req.path,
+    query: req.query,
+    httpVersion: req.httpVersion,
+    fresh: req.fresh,
+    xhr: req.xhr,
   });
 
   // we bind the method that finishes the request event so that we're guaranteed to get an event
@@ -119,17 +120,17 @@ const getMagicMiddleware = ({ userContext, requestIdSource }) => (req, res, next
     }
 
     event.addContext({
-      ["express.status_code"]: String(response.statusCode),
+      statusCode: String(response.statusCode),
     });
     if (req.params) {
       Object.keys(req.params).forEach(param =>
         event.addContext({
-          [`express.param.${param}`]: req.params[param],
+          [`param.${param}`]: req.params[param],
         })
       );
     }
 
-    event.finishRequest(ev, "express.response_time_ms");
+    event.finishRequest(ev);
   });
 
   onHeaders(res, function() {

--- a/lib/magic/express-magic.test.js
+++ b/lib/magic/express-magic.test.js
@@ -1,6 +1,7 @@
 /* global require expect describe test beforeEach afterEach */
 const request = require("supertest"),
   instrumentExpress = require("./express-magic"),
+  schema = require("../schema"),
   event = require("../event");
 
 const tests = [
@@ -51,27 +52,27 @@ for (let t of tests) {
           delete ev.startTime;
           delete ev.startTimeHR;
           expect(ev).toEqual({
-            "meta.request_id": 0,
-            "meta.type": "express",
-            "express.hostname": "127.0.0.1",
-            "express.baseUrl": "",
-            "express.url": "/",
-            "express.route": undefined,
-            "express.originalUrl": "/",
-            "express.ip": "::ffff:127.0.0.1",
-            "express.secure": false,
-            "express.method": "GET",
-            "express.protocol": "http",
-            "express.path": "/",
-            "express.query": {},
-            "express.http_version": "1.1",
-            "express.fresh": false,
-            "express.xhr": false,
-            "express.user.id": 42,
-            "express.user.username": "toshok",
-            "express.status_code": "200",
+            [schema.REQUEST_ID]: 0,
+            [schema.EVENT_TYPE]: "express",
+            [schema.DURATION_MS]: 0,
+            hostname: "127.0.0.1",
+            baseUrl: "",
+            url: "/",
+            route: undefined,
+            originalUrl: "/",
+            ip: "::ffff:127.0.0.1",
+            secure: false,
+            method: "GET",
+            protocol: "http",
+            path: "/",
+            query: {},
+            httpVersion: "1.1",
+            fresh: false,
+            xhr: false,
+            "user.id": 42,
+            "user.username": "toshok",
+            statusCode: "200",
             appEventPrefix: null,
-            "express.response_time_ms": 0,
           });
           event.apiForTesting().sentEvents.splice(0, 1);
           done();
@@ -117,7 +118,7 @@ describe("userContext as function", () => {
         expect(cb_called).toBe(true);
         expect(event.apiForTesting().sentEvents.length).toBe(1);
         let ev = event.apiForTesting().sentEvents[0];
-        expect(ev["express.user.random"]).toBe("stuff");
+        expect(ev["user.random"]).toBe("stuff");
         done();
       });
   });
@@ -153,8 +154,8 @@ describe("request id from http headers", () => {
       .expect(200, () => {
         expect(event.apiForTesting().sentEvents.length).toBe(1);
         let ev = event.apiForTesting().sentEvents[0];
-        expect(ev["meta.request_id"]).toBe("abc123");
-        expect(ev["meta.request_id_source"]).toBe("X-Request-ID http header");
+        expect(ev[schema.REQUEST_ID]).toBe("abc123");
+        expect(ev[schema.REQUEST_ID_SOURCE]).toBe("X-Request-ID http header");
         done();
       });
   });
@@ -166,8 +167,8 @@ describe("request id from http headers", () => {
       .expect(200, () => {
         expect(event.apiForTesting().sentEvents.length).toBe(1);
         let ev = event.apiForTesting().sentEvents[0];
-        expect(ev["meta.request_id"]).toBe("Root=1-67891233-abcdef012345678912345678");
-        expect(ev["meta.request_id_source"]).toBe("X-Amzn-Trace-Id http header");
+        expect(ev[schema.REQUEST_ID]).toBe("Root=1-67891233-abcdef012345678912345678");
+        expect(ev[schema.REQUEST_ID_SOURCE]).toBe("X-Amzn-Trace-Id http header");
         done();
       });
   });
@@ -180,8 +181,8 @@ describe("request id from http headers", () => {
       .expect(200, () => {
         expect(event.apiForTesting().sentEvents.length).toBe(1);
         let ev = event.apiForTesting().sentEvents[0];
-        expect(ev["meta.request_id"]).toBe("abc123");
-        expect(ev["meta.request_id_source"]).toBe("X-Request-ID http header");
+        expect(ev[schema.REQUEST_ID]).toBe("abc123");
+        expect(ev[schema.REQUEST_ID_SOURCE]).toBe("X-Request-ID http header");
         done();
       });
   });
@@ -219,8 +220,8 @@ describe("request id callback", () => {
       .expect(200, () => {
         expect(event.apiForTesting().sentEvents.length).toBe(1);
         let ev = event.apiForTesting().sentEvents[0];
-        expect(ev["meta.request_id"]).toBe("abc123");
-        expect(ev["meta.request_id_source"]).toBe("requestIdSource function");
+        expect(ev[schema.REQUEST_ID]).toBe("abc123");
+        expect(ev[schema.REQUEST_ID_SOURCE]).toBe("requestIdSource function");
         done();
       });
   });
@@ -231,8 +232,8 @@ describe("request id callback", () => {
       .expect(200, () => {
         expect(event.apiForTesting().sentEvents.length).toBe(1);
         let ev = event.apiForTesting().sentEvents[0];
-        expect(ev["meta.request_id"]).toBe("efgh456");
-        expect(ev["meta.request_id_source"]).toBe("requestIdSource function");
+        expect(ev[schema.REQUEST_ID]).toBe("efgh456");
+        expect(ev[schema.REQUEST_ID_SOURCE]).toBe("requestIdSource function");
         done();
       });
   });

--- a/lib/magic/http-magic.test.js
+++ b/lib/magic/http-magic.test.js
@@ -1,6 +1,7 @@
 /* global require expect test beforeAll afterAll */
 const http = require("http"),
   instrumentHttp = require("./http-magic"),
+  schema = require("../schema"),
   tracker = require("../async_tracker"),
   event = require("../event");
 
@@ -28,7 +29,7 @@ test("GET http://localhost:9009/ works", done => {
   http.get("http://localhost:9009", _res => {
     expect(tracker.getTracked()).toBe(context);
     expect(event.apiForTesting().sentEvents.length).toBe(1);
-    expect(event.apiForTesting().sentEvents[0]["meta.type"]).toBe("http");
+    expect(event.apiForTesting().sentEvents[0][schema.EVENT_TYPE]).toBe("http");
     expect(event.apiForTesting().sentEvents[0].appEventPrefix).toBe("request");
     expect(event.apiForTesting().sentEvents[0].url).toBe("http://localhost:9009");
     done();

--- a/lib/magic/https-magic.test.js
+++ b/lib/magic/https-magic.test.js
@@ -1,6 +1,7 @@
 /* global require expect beforeAll test */
 const https = require("https"),
   instrumentHttps = require("./https-magic"),
+  schema = require("../schema"),
   tracker = require("../async_tracker"),
   event = require("../event");
 
@@ -19,7 +20,7 @@ test("GET https://google.com works", done => {
   https.get("https://google.com", _res => {
     expect(tracker.getTracked()).toBe(context);
     expect(event.apiForTesting().sentEvents.length).toBe(1);
-    expect(event.apiForTesting().sentEvents[0]["meta.type"]).toBe("https");
+    expect(event.apiForTesting().sentEvents[0][schema.EVENT_TYPE]).toBe("https");
     expect(event.apiForTesting().sentEvents[0].appEventPrefix).toBe("request");
     expect(event.apiForTesting().sentEvents[0].url).toBe("https://google.com");
     done();

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,0 +1,10 @@
+/* global exports */
+
+exports.EVENT_TYPE = "meta.type"; // XXX(toshok) rename "type" to "source"?
+exports.REQUEST_ID = "meta.request_id";
+exports.REQUEST_ID_SOURCE = "meta.request_id_source";
+exports.INSTRUMENTATIONS = "meta.instrumentations";
+exports.INSTRUMENTATION_COUNT = "meta.instrumentation_count";
+exports.DURATION_MS = "durationMs";
+
+exports.customContext = key => `custom.${key}`;


### PR DESCRIPTION
adds `schema.js` which contains all the column names not specified by the magic modules themselves (meta.*, duration, etc.),
and make use of them everywhere.  that way we can bikeshed a bit more easily (without requiring global search and replace.)

While making this change, unify the duration_ms column with express's handling (response_time_ms) and land on durationMs for
everything.

Also, drop all of express's column prefixes, and camelCase its field names instead of snake_case.