### PR TITLE
more field name churn, add meta.onramp_version to events

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,35 +60,35 @@ For available configuration options per instrumentation, see the Instrumented pa
 * Which of my express app's endpoints are the slowest?
 
 ```
-BREAKDOWN: url
-CALCULATE: P99(durationMs)
+BREAKDOWN: request.url
+CALCULATE: P99(duration_ms)
 FILTER: meta.type == express
-ORDER BY: P99(durationMs) DESC
+ORDER BY: P99(duration_ms) DESC
 ```
 
 * Where's my app doing the most work / spending the most time?
 
 ```
 BREAKDOWN: meta.type
-CALCULATE: P99(durationMs)
-ORDER BY: P99(durationMs) DESC
+CALCULATE: P99(duration_ms)
+ORDER BY: P99(duration_ms) DESC
 ```
 
 * Which users are using the endpoint that I'd like to deprecate?
 
 ```
-BREAKDOWN: user.email
+BREAKDOWN: request.user.email
 CALCULATE: COUNT
-FILTER: url == <endpoint-url>
+FILTER: request.url == <endpoint-url>
 ```
 
 * Which XHR endpoints take the longest?
 
 ```
-BREAKDOWN: url
-CALCULATE: P99(durationMs)
-FILTER: meta.type == express AND xhr == true
-ORDER BY: P99(durationMs) DESC
+BREAKDOWN: request.url
+CALCULATE: P99(duration_ms)
+FILTER: meta.type == express AND request.xhr == true
+ORDER BY: P99(duration_ms) DESC
 ```
 
 # Example event
@@ -96,25 +96,25 @@ ORDER BY: P99(durationMs) DESC
 ```javascript
 {
   "Timestamp": "2018-03-20T00:47:25.339Z",
-  "baseUrl": "",
-  "fresh": false,
-  "hostname": "localhost",
-  "httpVersion": "1.1",
-  "ip": "127.0.0.1",
-  "method": "POST",
-  "originalUrl": "/checkValid",
-  "path": "/checkValid",
-  "protocol": "http",
-  "query": "{}",
-  "durationMs": 15.229326,
-  "secure": false,
-  "statusCode": "200",
-  "url": "/checkValid",
-  "xhr": true,
+  "request.base_url": "",
+  "request.fresh": false,
+  "request.hostname": "localhost",
+  "request.http_version": "1.1",
+  "request.ip": "127.0.0.1",
+  "request.method": "POST",
+  "request.original_url": "/checkValid",
+  "request.path": "/checkValid",
+  "request.protocol": "http",
+  "request.query": "{}",
+  "request.secure": false,
+  "request.url": "/checkValid",
+  "request.xhr": true,
+  "response.status_code": "200",
   "meta.instrumentation_count": 4,
   "meta.instrumentations": "[\"child_process\",\"express\",\"http\",\"https\"]",
   "meta.request_id": "11ad83a2-ca8d-4918-9db2-27524456d9f7",
   "meta.type": "express"
+  "duration_ms": 15.229326,
 }
 ```
 
@@ -145,7 +145,7 @@ For example:
 
 If `req.user` is an object `{ id: 1, username: "toshok" }` and your config settings include `express: { userContext: ["username"] }`, the following will be included in the express event sent to honeycomb:
 
-| `express.user.username` |
+| `request.user.username` |
 | :---------------------- |
 | `toshok`                |
 

--- a/lib/event.js
+++ b/lib/event.js
@@ -77,6 +77,7 @@ class MockEventAPI {
     Object.assign(ev, {
       appEventPrefix: rollup,
       [schema.DURATION_MS]: 0,
+      [schema.ONRAMP_VERSION]: pkg.version,
     });
     // pop it off the stack
     const idx = this.eventStack.indexOf(ev);
@@ -191,6 +192,7 @@ class LibhoneyEventAPI {
       ev.add({
         [schema.INSTRUMENTATIONS]: active_instrumentations,
         [schema.INSTRUMENTATION_COUNT]: active_instrumentation_count,
+        [schema.ONRAMP_VERSION]: pkg.version,
       });
       ev.send();
     });

--- a/lib/magic/express-magic.js
+++ b/lib/magic/express-magic.js
@@ -75,7 +75,7 @@ const getUserContext = (userContext, req) => {
   for (const k of keys) {
     const v = userObject[k];
     if (typeof v !== "function") {
-      userEventContext[`user.${k}`] = v;
+      userEventContext[`request.user.${k}`] = v;
     }
   }
   return userEventContext;
@@ -91,26 +91,21 @@ const getMagicMiddleware = ({ userContext, requestIdSource, packageVersion }) =>
 
   event.addContext({
     [schema.REQUEST_ID_SOURCE]: requestIdContext.source,
-  });
-  event.addContext({
     [schema.PACKAGE_VERSION]: packageVersion,
-  });
-
-  event.addContext({
-    hostname: req.hostname,
-    baseUrl: req.baseUrl,
-    url: req.url,
-    originalUrl: req.originalUrl,
-    ip: req.ip,
-    secure: req.secure,
-    method: req.method,
-    route: req.route ? req.route.path : undefined,
-    protocol: req.protocol,
-    path: req.path,
-    query: req.query,
-    httpVersion: req.httpVersion,
-    fresh: req.fresh,
-    xhr: req.xhr,
+    "request.hostname": req.hostname,
+    "request.base_url": req.baseUrl,
+    "request.url": req.url,
+    "request.original_url": req.originalUrl,
+    "request.ip": req.ip,
+    "request.secure": req.secure,
+    "request.method": req.method,
+    "request.route": req.route ? req.route.path : undefined,
+    "request.protocol": req.protocol,
+    "request.path": req.path,
+    "request.query": req.query,
+    "request.http_version": req.httpVersion,
+    "request.fresh": req.fresh,
+    "request.xhr": req.xhr,
   });
 
   // we bind the method that finishes the request event so that we're guaranteed to get an event
@@ -127,12 +122,12 @@ const getMagicMiddleware = ({ userContext, requestIdSource, packageVersion }) =>
     }
 
     event.addContext({
-      statusCode: String(response.statusCode),
+      "response.status_code": String(response.statusCode),
     });
     if (req.params) {
       Object.keys(req.params).forEach(param =>
         event.addContext({
-          [`param.${param}`]: req.params[param],
+          [`request.param.${param}`]: req.params[param],
         })
       );
     }

--- a/lib/magic/express-magic.test.js
+++ b/lib/magic/express-magic.test.js
@@ -1,8 +1,10 @@
-/* global require expect describe test beforeEach afterEach */
+/* global __dirname require expect describe test beforeEach afterEach */
 const request = require("supertest"),
+  path = require("path"),
   instrumentExpress = require("./express-magic"),
   schema = require("../schema"),
-  event = require("../event");
+  event = require("../event"),
+  pkg = require(path.join(__dirname, "..", "..", "package.json"));
 
 const tests = [
   {
@@ -62,23 +64,24 @@ for (let t of tests) {
             [schema.EVENT_TYPE]: "express",
             [schema.PACKAGE_VERSION]: "1.1.1",
             [schema.DURATION_MS]: 0,
-            hostname: "127.0.0.1",
-            baseUrl: "",
-            url: "/",
-            route: undefined,
-            originalUrl: "/",
-            ip: "::ffff:127.0.0.1",
-            secure: false,
-            method: "GET",
-            protocol: "http",
-            path: "/",
-            query: {},
-            httpVersion: "1.1",
-            fresh: false,
-            xhr: false,
-            "user.id": 42,
-            "user.username": "toshok",
-            statusCode: "200",
+            [schema.ONRAMP_VERSION]: pkg.version,
+            "request.hostname": "127.0.0.1",
+            "request.base_url": "",
+            "request.url": "/",
+            "request.route": undefined,
+            "request.original_url": "/",
+            "request.ip": "::ffff:127.0.0.1",
+            "request.secure": false,
+            "request.method": "GET",
+            "request.protocol": "http",
+            "request.path": "/",
+            "request.query": {},
+            "request.http_version": "1.1",
+            "request.fresh": false,
+            "request.xhr": false,
+            "request.user.id": 42,
+            "request.user.username": "toshok",
+            "response.status_code": "200",
             appEventPrefix: null,
           });
           event.apiForTesting().sentEvents.splice(0, 1);
@@ -125,7 +128,7 @@ describe("userContext as function", () => {
         expect(cb_called).toBe(true);
         expect(event.apiForTesting().sentEvents.length).toBe(1);
         let ev = event.apiForTesting().sentEvents[0];
-        expect(ev["user.random"]).toBe("stuff");
+        expect(ev["request.user.random"]).toBe("stuff");
         done();
       });
   });

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,11 +1,12 @@
 /* global exports */
 
 exports.EVENT_TYPE = "meta.type"; // XXX(toshok) rename "type" to "source"?
+exports.ONRAMP_VERSION = "meta.onramp_version";
 exports.PACKAGE_VERSION = "meta.version";
 exports.REQUEST_ID = "meta.request_id";
 exports.REQUEST_ID_SOURCE = "meta.request_id_source";
 exports.INSTRUMENTATIONS = "meta.instrumentations";
 exports.INSTRUMENTATION_COUNT = "meta.instrumentation_count";
-exports.DURATION_MS = "durationMs";
+exports.DURATION_MS = "duration_ms";
 
 exports.customContext = key => `custom.${key}`;


### PR DESCRIPTION
`onramp_version` is the version string for our package, so people can track that over time too.

introduce two namespaces back into express events:  `request.` and `response.`.  everything
is nested under one of those.  The other instrumentations don't have namespaces.

`durationMs` is back to being `duration_ms` after more angsting about snake_case vs camelCase with the other onramps.